### PR TITLE
Fix handling of IN and BETWEEN in scan_items

### DIFF
--- a/lib/Net/Amazon/DynamoDB.pm
+++ b/lib/Net/Amazon/DynamoDB.pm
@@ -1938,14 +1938,17 @@ sub scan_items {
             my $rvalue = ref( $val_ref ) || '';
             if ( $rvalue eq 'HASH' ) {
                 my ( $op, $value ) = %$val_ref;
+                my $value_list = (ref $value eq 'ARRAY')
+                    ? [ map { { $type => $_."" } } @$value ]
+                    : [ { $type => $value. '' } ];
                 $s_ref->{ $key } = {
-                    AttributeValueList => [ { $type => $value. '' } ],
+                    AttributeValueList => $value_list,
                     ComparisonOperator => uc( $op )
                 };
             }
             elsif( $rvalue eq 'ARRAY' ) {
                 $s_ref->{ $key } = {
-                    AttributeValueList => [ { $type => $val_ref } ],
+                    AttributeValueList => [ map { { $type => $_."" } } @$val_ref ],
                     ComparisonOperator => 'IN'
                 };
             }


### PR DESCRIPTION
Hazards of roll-your-own JSON. Handling of array ref shortcut for IN, and both IN and BETWEEN in hash ref style filter args, has been broken since... well, forever...

Fix in the style of the rest of the code, much as I'm tempted to rewrite it all :D